### PR TITLE
Polish README and ignore sensitive files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,22 +1,7 @@
-# Python
 __pycache__/
 *.py[cod]
-*$py.class
-
-# Virtual Environment
-venv/
-env/
+chat_app.db
+.streamlit/secrets.toml
 .env
-
-# Streamlit
-.streamlit/
-
-# OS generated files
-.DS_Store
-Thumbs.db
-
-# Editor directories and files
-.idea/
 .vscode/
-*.swp
-*.swo
+.idea/

--- a/README.md
+++ b/README.md
@@ -1,61 +1,79 @@
-# CPDI Q&A App
+# AllianceGPT — Groq-powered Q&A hub
 
-## Description
-The CPDI Q&A App is a Streamlit-based web application that provides a chat interface for users to ask questions and receive answers. It uses the Groq API for generating responses and includes user authentication, chat history, and administrative features.
+A lightweight Streamlit app that pairs Groq’s Mixtral completion with a simple SQLite-backed chat experience. It offers user registration, persistent chat history, and a small admin dashboard with analytics, CSV downloads, and user management hooks so you can quickly prototype a private, team-friendly assistant.
 
 ## Features
-- User registration and authentication
-- Chat interface for asking questions
 
-- Integration with Groq API for AI-powered responses
+- Register/login flows with bcrypt-hashed credentials (admin account seeded via secrets)
+- Persistent chat history stored locally in `chat_app.db`
+- Groq chat completions streamed directly into the interface (model: `mixtral-8x7b-32768`)
+- Admin dashboard with metrics (daily/hourly query trends, top users), live chat logs, and database download/reset controls
+- User deletion utility for cleaning up test accounts from the demo environment
 
-## Installation
+## Tech stack
 
-1. Clone the repository:
-   ```
-   git clone <repository-url>
-   cd cpdi-qa-app
-   ```
+- [Streamlit](https://streamlit.io/) for UI + state management
+- [Groq Realtime API](https://groq.com/) (`Groq` Python client) for LLM responses
+- SQLite for lightweight persistence
+- Plotly and pandas for analytics charts
+- bcrypt for password hashing
 
-2. Install the required dependencies:
-   ```
-   pip install -r requirements.txt
-   ```
+## Getting started
 
-3. Set up your Groq API key:
-   - Create a `.streamlit/secrets.toml` file in the project root
-   - Add your Groq API key to the file:
-     ```
-     GROQ_API_KEY = "your-api-key-here"
-     ```
+### 1. Clone & install
 
-## Usage
+```bash
+git clone https://github.com/samsontands/AllianceGPT.git
+cd AllianceGPT
+pip install -r requirements.txt
+```
 
-1. Run the Streamlit app:
-   ```
-   streamlit run app.py
-   ```
+### 2. Configure secrets
 
-2. Open your web browser and navigate to the URL provided by Streamlit (usually `http://localhost:8501`).
+Create a `.streamlit/secrets.toml` file (and keep it outside version control):
 
-3. Sign up for a new account or log in with existing credentials.
+```toml
+GROQ_API_KEY = "your-groq-api-key"
+ADMIN_PASSWORD = "choose-a-secure-admin-password"
+```
 
-4. Start chatting and asking questions!
+The app uses `st.secrets` to hydrate both the Groq client and the seeded admin credentials.
 
+### 3. Run the app
 
-## Dependencies
-- streamlit
-- sqlite3
-- groq
-- bcrypt
-- pandas
+```bash
+streamlit run groq_streamlit_app.py
+```
 
-## Security Notes
-- Passwords are hashed using bcrypt before being stored in the database.
-- The admin account is hardcoded for demonstration purposes. In a production environment, implement a more secure method for admin account creation and management.
+Streamlit will open `http://localhost:8501` by default.
+
+## Admin notes
+
+- Admin user: `samson tan` (password defined above).
+- Admin controls expose a database download button, reset hook, chat log CSV export, and user deletion dropdown.
+- `chat_app.db` lives in the project root; keep it out of git by honoring `.gitignore` (provided).
+- Use `st.cache_data.clear()` + `st.cache_resource.clear()` from the dashboard to flush cached analytics if you train locally.
+
+## Development
+
+- The Groq client is created in `init_groq_client()` and set to stream completions, so you can watch tokens appear in the UI and reuse the same `client` instance per session.
+- Analytics queries rely on the `chats` table; if you need a fresh start, click _Reinitialize Database_ under admin controls.
+- Extend `get_top_users()`, `get_mean_daily_query_data()`, and `get_mean_hourly_query_data()` for more dashboards.
+
+## Security & privacy
+
+- Passwords are hashed via bcrypt before storage.
+- The public admin username is hardcoded for demo purposes; replace it with a proper onboarding flow before deploying.
+- Never commit `.streamlit/secrets.toml` or `chat_app.db` to GitHub. Use environment variables or secret managers in production.
 
 ## Contributing
-Contributions to improve the CPDI Q&A App are welcome. Please feel free to submit pull requests or open issues to discuss proposed changes.
+
+Happy to collaborate! Open an issue with your idea, or send a pull request. Focus areas right now:
+
+- Introduce unit tests for the persistence layer
+- Swap SQLite for Postgres (if the app will be multi-user)
+- Add role-based access controls beyond the single admin flag
 
 ## License
-[Specify your license here]
+
+Add your license information (MIT, Apache 2.0, etc.) here.


### PR DESCRIPTION
## Summary
- refresh the README to explain the Groq-backed Streamlit chat app and highlight setup/admin/security notes
- add a .gitignore so generated SQLite, secrets, and editor files stay out of git
